### PR TITLE
Project section updates

### DIFF
--- a/docs/_project/dao-treasury.md
+++ b/docs/_project/dao-treasury.md
@@ -9,14 +9,12 @@ last_modified_date: 2022-11-28
 DAO Treasury
 ============
 
-The majority of the DAO's tokens are held in a multi-signature wallet post-TGE.
-This is a smart contract that require the agreement of five of the nine (signers) to perform an action. 
+### Forge Contract = DAO Treasury
 
-Multiple private keys held by members of the community are required to execute any transaction using the contract.
+The Forge is seeded with $YFD which can be accessed using an on-chain governance *Spend* proposal.
 
-The Treasury Multi-sig is useful for protecting assets (through separation of duties) and helps ensure that certain actions are only taken in accordance with will of the signers.
-
-For more information on this, please read [Proposals]().
+{: .note }
+For MVP the Forge is back-stopped with an on-chain 5 of 9 signer multi-signature wallet holding the majority of the $YFD tokens. The majority of the DAO's tokens are held in this multi-signature wallet post-TGE. This is a smart contract that requires the agreement of five of the nine (signers) to perform an action. The Treasury Multi-sig serves as a useful stopgap to ensure the healthy operation of the platform through MVP launch prior to moving all funds to the DAO treasury.
 
 ### Multi-Sig Signers
 
@@ -32,9 +30,3 @@ For more information on this, please read [Proposals]().
 | Signer 8 |    |
 | Signer 9 |    |
 
-
-### Forge Contract = DAO Treasury
-
-The Forge is seeded with $YFD which can be accessed using an on-chain governance *Spend* proposal.
-
-For MVP the Forge is back-stopped with an on-chain 5 of 9 signer multi-signature wallet holding the majority of the $YFD tokens.

--- a/docs/_project/progress.md
+++ b/docs/_project/progress.md
@@ -9,7 +9,7 @@ last_modified_date: 2022-11-28
 Progress
 =======
 
-Below you will find more details on YFD's future plans, milestones reached and current objectives.
+Below you will find more details on YFD's milestones reached and current objectives.
 
 ![](/assets/images/figure/progress.png)
 
@@ -38,11 +38,4 @@ Below you will find more details on YFD's future plans, milestones reached and c
 
 [  ]   Q4: UI/UX
 
-2023:
---------------------------------------------------------------------------------
-
-[ ]   Q1: TBD
-
-[ ]   Q2: TBD
-
-[ ]   Q3
+[  ]   Q4: MVP Launch!

--- a/docs/_project/tokenomics.md
+++ b/docs/_project/tokenomics.md
@@ -23,7 +23,7 @@ The Y-Foundry token information:
 
 ### Distribution
 
-The $YFD token distribution can be seen in the table below. Second to the [DAO Treasury](/project/finances/dao-treasury/), 23% of the token supply goes toward Genesis Contributors and Investors, with 6.9% going toward Airdrops.
+The $YFD token distribution can be seen in the table below. Second to the [DAO Treasury](/project/dao-treasury/), 23% of the token supply goes toward Genesis Contributors and Investors, with 6.9% going toward Airdrops.
 
 ![](/assets/images/chart/yfd-distribution.png)
 


### PR DESCRIPTION
- dao-treasury - cleaned up redundant text and made the temporary nature of the multi-sig more clear
- progress - removed "future plans" and the 2023 from the roadmap
- tokenomics - updated the link to "dao-treasury